### PR TITLE
feature: adding optional DTO mapping functionality

### DIFF
--- a/IndexCloner.csproj
+++ b/IndexCloner.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Search.Documents" Version="11.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/NewDoc.cs
+++ b/NewDoc.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace IndexCloner
+{
+    public class NewDoc
+    {
+        public NewDoc(string _newFieldOne)
+        {
+            newFieldOne = _newFieldOne;
+        }
+
+        [JsonConstructor]
+        public NewDoc(
+            string _newFieldOne,
+            string _newFieldTwo,
+            string _newFieldThree
+        )
+        {
+            newFieldOne = _newFieldOne;
+            newFieldTwo = _newFieldTwo;
+            newFieldThree = _newFieldThree;
+        }
+
+        [JsonProperty("newFieldOne")]
+        public string newFieldOne { get; set; }
+
+        [JsonProperty("newFieldTwo")]
+        public string newFieldTwo { get; set; }
+
+        [JsonProperty("newFieldThree")]
+        public string newFieldThree { get; set; }
+    }
+}

--- a/OldDoc.cs
+++ b/OldDoc.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace IndexCloner
+{
+    public class OldDoc
+    {
+        public OldDoc(string _oldFieldOne)
+        {
+            oldFieldOne = _oldFieldOne;
+        }
+
+        [JsonConstructor]
+        public OldDoc(
+            string _oldFieldOne,
+            string _oldFieldTwo
+        )
+        {
+            oldFieldOne = _oldFieldOne;
+            oldFieldTwo = _oldFieldTwo;
+        }
+
+        [JsonProperty("oldFieldOne")]
+        public string oldFieldOne { get; set; }
+
+        [JsonProperty("oldFieldTwo")]
+        public string oldFieldTwo { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -41,19 +41,23 @@ namespace IndexCloner
 
         static JsonElement Map(JsonElement input)
         {
-            string inputText = input.GetRawText();
-            OldDoc oldDoc = JsonSerializer.Deserialize<OldDoc>(inputText, new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            });
+            // 1:1 cloning with no DTO shape changing:
+            return input;
 
-            NewDoc newDoc = new NewDoc(
-                oldDoc.oldFieldOne,
-                oldDoc.oldFieldTwo,
-                "Hard coded string because OldDoc didn't have an equivalent"
-            );
-            JsonElement elementToReturn = JsonElementFromObject(newDoc);
-            return elementToReturn;
+            // Mapping between two DTO's of different shape:
+            // string inputText = input.GetRawText();
+            // OldDoc oldDoc = JsonSerializer.Deserialize<OldDoc>(inputText, new JsonSerializerOptions
+            // {
+            //     PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            // });
+            //
+            // NewDoc newDoc = new NewDoc(
+            //     oldDoc.oldFieldOne,
+            //     oldDoc.oldFieldTwo,
+            //     "Hard coded string because OldDoc didn't have an equivalent"
+            // );
+            // JsonElement elementToReturn = JsonElementFromObject(newDoc);
+            // return elementToReturn;
         }
 
         static async Task Main(string[] args)
@@ -111,7 +115,7 @@ namespace IndexCloner
                 );
             }
 
-            //Console.WriteLine($"Commencing data migration for {indexToClone} to {destinationSearchService}");
+            Console.WriteLine($"Commencing data migration for {indexToClone} to {destinationSearchService}");
             var dataMigrationTimer = new Stopwatch();
             dataMigrationTimer.Start();
             var indexBatch = new IndexDocumentsBatch<JsonElement>();

--- a/Program.cs
+++ b/Program.cs
@@ -65,7 +65,7 @@ namespace IndexCloner
             if (args.Length == 1 && IsHelpParam(args[0]))
             {
                 Console.WriteLine(
-                    "Help: usage IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <index-name> <filter-field> [copyIndexDefinition]");
+                    "Help: usage IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <source-index-name> <destination-index-name> <filter-field> [copyIndexDefinition]");
                 Environment.Exit(0);
                 return;
             }
@@ -73,7 +73,7 @@ namespace IndexCloner
             if (args.Length != 7 && args.Length != 8)
             {
                 await Console.Error.WriteLineAsync(
-                    "Error: usage IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <index-name> <filter-field> [copyIndexDefinition]");
+                    "Error: usage IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <source-index-name> <destination-index-name> <filter-field> [copyIndexDefinition]");
                 Environment.Exit(-1);
                 return;
             }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "IndexCloner": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -7,17 +7,23 @@ e.g. `IndexCloner.exe service-one AEF345349023CD service-two CED35734902EEF copy
 
 ## Caveats and limitations
 
-- All the fields on the source need to be marked as retreivable, if they are not you will loose the data in those fields
-- The filter-field must be both sortable and retrievable
-- This tool currently provides no re-try logic for failed actions
-- If there are changes to the data in the source during execution of this tool they may not be captured and migrated to the destination index
-- I'm making this available for use for free, I provide no warranties express or implied, use at your own risk
-- That said it worked just fine for my case.
+* All the fields on the source need to be marked as retreivable, if they are not you will loose the data in those fields
+* The filter-field must be both sortable and retrievable
+* This tool currently provides no re-try logic for failed actions
+* If there are changes to the data in the source during execution of this tool they may not be captured and migrated to the destination index
+* I'm making this available for use for free, I provide no warranties express or implied, use at your own risk
+* That said it worked just fine for my case.
 
 ## FAQ
 
-- Why is a filter-field required?
+* Why is a filter-field required?
 
 > The Azure Search service has a [hard limit of 100K for the $skip](https://docs.microsoft.com/en-us/rest/api/searchservice/search-documents#skip-optional)
-> parameter which is used in OData to page through results without a field to build ordered filtered queries against
-> this tool would be unable to handle indexes with > 100,000 records
+parameter which is used in OData to page through results without a field to build ordered filtered queries against
+this tool would be unable to handle indexes with > 100,000 records
+
+* Must the fields in the destination index be the same as the fields in the source index?
+
+> By default the tool performs a 1:1 clone of the source index with all fields retained.
+However, if there is a need for the data to be mutated during the copy, a `map` function is provided.
+Using that function, you can define the fields present in both the source and destination index DTOs and map fields between them.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,22 +2,22 @@
 
 A simple dotnet core 3.1 utility to copy an Azure Search index from one search service to another. This tool is built using the [Version 11 of the Azure Cognitive Search libraries for .NET](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/search?view=azure-dotnet)
 
-Usage: `IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <index-name> <filter-field> [copyIndexDefinition]`  
-e.g. `IndexCloner.exe service-one AEF345349023CD service-two CED35734902EEF copy-me lastUpdate true`
+Usage: `IndexCloner.exe <source-search-service-name> <source-search-service-key> <destination-search-service-name> <destination-search-service-key> <source-index-name> <destination-index-name> <filter-field> [copyIndexDefinition]`  
+e.g. `IndexCloner.exe service-one AEF345349023CD service-two CED35734902EEF copy-me into-me lastUpdate true`
 
 ## Caveats and limitations
 
-* All the fields on the source need to be marked as retreivable, if they are not you will loose the data in those fields
-* The filter-field must be both sortable and retrievable
-* This tool currently provides no re-try logic for failed actions
-* If there are changes to the data in the source during execution of this tool they may not be captured and migrated to the destination index
-* I'm making this available for use for free, I provide no warranties express or implied, use at your own risk
-* That said it worked just fine for my case.
+- All the fields on the source need to be marked as retreivable, if they are not you will loose the data in those fields
+- The filter-field must be both sortable and retrievable
+- This tool currently provides no re-try logic for failed actions
+- If there are changes to the data in the source during execution of this tool they may not be captured and migrated to the destination index
+- I'm making this available for use for free, I provide no warranties express or implied, use at your own risk
+- That said it worked just fine for my case.
 
 ## FAQ
 
-* Why is a filter-field required?  
+- Why is a filter-field required?
 
 > The Azure Search service has a [hard limit of 100K for the $skip](https://docs.microsoft.com/en-us/rest/api/searchservice/search-documents#skip-optional)
-parameter which is used in OData to page through results without a field to build ordered filtered queries against
-this tool would be unable to handle indexes with > 100,000 records
+> parameter which is used in OData to page through results without a field to build ordered filtered queries against
+> this tool would be unable to handle indexes with > 100,000 records


### PR DESCRIPTION
Default behaviour unchanged, with exception of extra startup argument.

Adds optional functionality which allows the user to map the source index structure to a different destination structure, includes example with stubbed out classes `OldDoc` and `NewDoc`